### PR TITLE
Startup redis on port 7777 on agent start

### DIFF
--- a/conf/redis.toml
+++ b/conf/redis.toml
@@ -1,0 +1,6 @@
+[startup.redis]
+name = "execute"
+
+[startup.redis.args]
+name = "redis-server"
+args = ["--port", "7777"]


### PR DESCRIPTION
This redis instance is going to be used by the aggregator for statistics
The influxdumper processes will read the aggregated data from this instance and dump it into influxdb

#Author: Muhamd Azmy <muhamad.azmy@codescalers.com>